### PR TITLE
Hotfix/update dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var search = require('nlcst-search');
 var toString = require('nlcst-to-string');
 var quotation = require('quotation');
 var findBefore = require('unist-util-find-before');
-var difference = require('lodash.difference');
+var difference = require('lodash/difference');
 
 var MODULENAME = 'retext-assuming';
 var PREFIX = 'Avoid';

--- a/package-lock.json
+++ b/package-lock.json
@@ -2285,10 +2285,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-			"dev": true
+			"version": "4.17.15",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
@@ -2301,11 +2300,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
 			"integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
 			"dev": true
-		},
-		"lodash.difference": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-			"integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
 		},
 		"lodash.isequal": {
 			"version": "4.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -125,9 +125,9 @@
 			"dev": true
 		},
 		"argparse": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+			"version": "1.0.10",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
@@ -534,9 +534,9 @@
 			"dev": true
 		},
 		"cached-path-relative": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
-			"integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
+			"version": "1.0.2",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/cached-path-relative/-/cached-path-relative-1.0.2.tgz",
+			"integrity": "sha1-oT30GW0md2IgzDNW6xR6Utuixts=",
 			"dev": true
 		},
 		"caller-path": {
@@ -916,9 +916,9 @@
 			"dev": true
 		},
 		"deep-extend": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+			"version": "0.6.0",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
 			"dev": true
 		},
 		"deep-is": {
@@ -1465,9 +1465,9 @@
 			}
 		},
 		"esprima": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+			"version": "4.0.1",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
 			"dev": true
 		},
 		"espurify": {
@@ -1558,9 +1558,9 @@
 			"dev": true
 		},
 		"extend": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+			"version": "3.0.2",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
 			"dev": true
 		},
 		"fast-levenshtein": {
@@ -1638,14 +1638,17 @@
 			"dev": true
 		},
 		"generate-function": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-			"dev": true
+			"version": "2.3.1",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/generate-function/-/generate-function-2.3.1.tgz",
+			"integrity": "sha1-8GlhdpDBDIaOc7hGV0Z2T5fDR58=",
+			"dev": true,
+			"requires": {
+				"is-property": "^1.0.2"
+			}
 		},
 		"generate-object-property": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/generate-object-property/-/generate-object-property-1.2.0.tgz",
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
 			"dev": true,
 			"requires": {
@@ -2026,14 +2029,21 @@
 				"js-types": "^1.0.0"
 			}
 		},
+		"is-my-ip-valid": {
+			"version": "1.0.0",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+			"integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
+			"dev": true
+		},
 		"is-my-json-valid": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-			"integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+			"version": "2.20.0",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
+			"integrity": "sha1-E0Wm/KPo2u/BDQ+ncGf1TO2v1Zo=",
 			"dev": true,
 			"requires": {
 				"generate-function": "^2.0.0",
 				"generate-object-property": "^1.1.0",
+				"is-my-ip-valid": "^1.0.0",
 				"jsonpointer": "^4.0.0",
 				"xtend": "^4.0.0"
 			}
@@ -2092,7 +2102,7 @@
 		},
 		"is-property": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/is-property/-/is-property-1.0.2.tgz",
 			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
 			"dev": true
 		},
@@ -2179,9 +2189,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+			"version": "3.13.1",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
 			"dev": true,
 			"requires": {
 				"argparse": "^1.0.7",
@@ -2211,7 +2221,7 @@
 		},
 		"jsonpointer": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/jsonpointer/-/jsonpointer-4.0.1.tgz",
 			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
 			"dev": true
 		},
@@ -3074,12 +3084,12 @@
 			}
 		},
 		"rc": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-			"integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+			"version": "1.2.8",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
 			"dev": true,
 			"requires": {
-				"deep-extend": "~0.4.0",
+				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
 				"minimist": "^1.2.0",
 				"strip-json-comments": "~2.0.1"
@@ -3161,9 +3171,9 @@
 			}
 		},
 		"registry-auth-token": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-			"integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+			"version": "3.4.0",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+			"integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
 			"dev": true,
 			"requires": {
 				"rc": "^1.1.6",
@@ -3460,7 +3470,7 @@
 		},
 		"sprintf-js": {
 			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"resolved": "https://ryte.jfrog.io/ryte/api/npm/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
 			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
 			"dev": true
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
 			"integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
 			"dev": true,
 			"requires": {
-				"jsonparse": "1.3.1",
-				"through": "2.3.8"
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
 			}
 		},
 		"acorn": {
@@ -26,7 +26,7 @@
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"dev": true,
 			"requires": {
-				"acorn": "3.3.0"
+				"acorn": "^3.0.4"
 			},
 			"dependencies": {
 				"acorn": {
@@ -43,8 +43,8 @@
 			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 			"dev": true,
 			"requires": {
-				"co": "4.6.0",
-				"json-stable-stringify": "1.0.1"
+				"co": "^4.6.0",
+				"json-stable-stringify": "^1.0.1"
 			},
 			"dependencies": {
 				"json-stable-stringify": {
@@ -53,7 +53,7 @@
 					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 					"dev": true,
 					"requires": {
-						"jsonify": "0.0.0"
+						"jsonify": "~0.0.0"
 					}
 				}
 			}
@@ -70,7 +70,7 @@
 			"integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
 			"dev": true,
 			"requires": {
-				"string-width": "2.1.1"
+				"string-width": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -91,8 +91,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -101,7 +101,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -130,7 +130,7 @@
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"array-differ": {
@@ -175,7 +175,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -196,9 +196,9 @@
 			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"bn.js": "^4.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"assert": {
@@ -216,7 +216,7 @@
 			"integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
 			"dev": true,
 			"requires": {
-				"acorn": "4.0.13"
+				"acorn": "^4.0.3"
 			}
 		},
 		"babel-code-frame": {
@@ -225,9 +225,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			}
 		},
 		"bail": {
@@ -260,13 +260,13 @@
 			"integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
 			"dev": true,
 			"requires": {
-				"ansi-align": "2.0.0",
-				"camelcase": "4.1.0",
-				"chalk": "2.3.0",
-				"cli-boxes": "1.0.0",
-				"string-width": "2.1.1",
-				"term-size": "1.2.0",
-				"widest-line": "1.0.0"
+				"ansi-align": "^2.0.0",
+				"camelcase": "^4.0.0",
+				"chalk": "^2.0.1",
+				"cli-boxes": "^1.0.0",
+				"string-width": "^2.0.0",
+				"term-size": "^1.2.0",
+				"widest-line": "^1.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -281,7 +281,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"camelcase": {
@@ -296,9 +296,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -313,8 +313,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -323,7 +323,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -334,7 +334,7 @@
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"dev": true,
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -350,11 +350,11 @@
 			"integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
 			"dev": true,
 			"requires": {
-				"JSONStream": "1.3.1",
-				"combine-source-map": "0.7.2",
-				"defined": "1.0.0",
-				"through2": "2.0.3",
-				"umd": "3.0.1"
+				"JSONStream": "^1.0.3",
+				"combine-source-map": "~0.7.1",
+				"defined": "^1.0.0",
+				"through2": "^2.0.0",
+				"umd": "^3.0.0"
 			}
 		},
 		"browser-resolve": {
@@ -380,53 +380,53 @@
 			"integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
 			"dev": true,
 			"requires": {
-				"JSONStream": "1.3.1",
-				"assert": "1.4.1",
-				"browser-pack": "6.0.2",
-				"browser-resolve": "1.11.2",
-				"browserify-zlib": "0.2.0",
-				"buffer": "5.0.8",
-				"cached-path-relative": "1.0.1",
-				"concat-stream": "1.5.2",
-				"console-browserify": "1.1.0",
-				"constants-browserify": "1.0.0",
-				"crypto-browserify": "3.11.1",
-				"defined": "1.0.0",
-				"deps-sort": "2.0.0",
-				"domain-browser": "1.1.7",
-				"duplexer2": "0.1.4",
-				"events": "1.1.1",
-				"glob": "7.1.2",
-				"has": "1.0.1",
-				"htmlescape": "1.1.1",
-				"https-browserify": "1.0.0",
-				"inherits": "2.0.3",
-				"insert-module-globals": "7.0.1",
-				"labeled-stream-splicer": "2.0.0",
-				"module-deps": "4.1.1",
-				"os-browserify": "0.3.0",
-				"parents": "1.0.1",
-				"path-browserify": "0.0.0",
-				"process": "0.11.10",
-				"punycode": "1.4.1",
-				"querystring-es3": "0.2.1",
-				"read-only-stream": "2.0.0",
-				"readable-stream": "2.3.3",
-				"resolve": "1.5.0",
-				"shasum": "1.0.2",
-				"shell-quote": "1.6.1",
-				"stream-browserify": "2.0.1",
-				"stream-http": "2.7.2",
-				"string_decoder": "1.0.3",
-				"subarg": "1.0.0",
-				"syntax-error": "1.3.0",
-				"through2": "2.0.3",
-				"timers-browserify": "1.4.2",
-				"tty-browserify": "0.0.0",
-				"url": "0.11.0",
-				"util": "0.10.3",
-				"vm-browserify": "0.0.4",
-				"xtend": "4.0.1"
+				"JSONStream": "^1.0.3",
+				"assert": "^1.4.0",
+				"browser-pack": "^6.0.1",
+				"browser-resolve": "^1.11.0",
+				"browserify-zlib": "~0.2.0",
+				"buffer": "^5.0.2",
+				"cached-path-relative": "^1.0.0",
+				"concat-stream": "~1.5.1",
+				"console-browserify": "^1.1.0",
+				"constants-browserify": "~1.0.0",
+				"crypto-browserify": "^3.0.0",
+				"defined": "^1.0.0",
+				"deps-sort": "^2.0.0",
+				"domain-browser": "~1.1.0",
+				"duplexer2": "~0.1.2",
+				"events": "~1.1.0",
+				"glob": "^7.1.0",
+				"has": "^1.0.0",
+				"htmlescape": "^1.1.0",
+				"https-browserify": "^1.0.0",
+				"inherits": "~2.0.1",
+				"insert-module-globals": "^7.0.0",
+				"labeled-stream-splicer": "^2.0.0",
+				"module-deps": "^4.0.8",
+				"os-browserify": "~0.3.0",
+				"parents": "^1.0.1",
+				"path-browserify": "~0.0.0",
+				"process": "~0.11.0",
+				"punycode": "^1.3.2",
+				"querystring-es3": "~0.2.0",
+				"read-only-stream": "^2.0.0",
+				"readable-stream": "^2.0.2",
+				"resolve": "^1.1.4",
+				"shasum": "^1.0.0",
+				"shell-quote": "^1.6.1",
+				"stream-browserify": "^2.0.0",
+				"stream-http": "^2.0.0",
+				"string_decoder": "~1.0.0",
+				"subarg": "^1.0.0",
+				"syntax-error": "^1.1.1",
+				"through2": "^2.0.0",
+				"timers-browserify": "^1.0.1",
+				"tty-browserify": "~0.0.0",
+				"url": "~0.11.0",
+				"util": "~0.10.1",
+				"vm-browserify": "~0.0.1",
+				"xtend": "^4.0.0"
 			}
 		},
 		"browserify-aes": {
@@ -435,12 +435,12 @@
 			"integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
 			"dev": true,
 			"requires": {
-				"buffer-xor": "1.0.3",
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.3",
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"buffer-xor": "^1.0.3",
+				"cipher-base": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.3",
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"browserify-cipher": {
@@ -449,9 +449,9 @@
 			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
 			"dev": true,
 			"requires": {
-				"browserify-aes": "1.1.1",
-				"browserify-des": "1.0.0",
-				"evp_bytestokey": "1.0.3"
+				"browserify-aes": "^1.0.4",
+				"browserify-des": "^1.0.0",
+				"evp_bytestokey": "^1.0.0"
 			}
 		},
 		"browserify-des": {
@@ -460,9 +460,9 @@
 			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"des.js": "1.0.0",
-				"inherits": "2.0.3"
+				"cipher-base": "^1.0.1",
+				"des.js": "^1.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"browserify-rsa": {
@@ -471,8 +471,8 @@
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"browserify-sign": {
@@ -481,13 +481,13 @@
 			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"elliptic": "6.4.0",
-				"inherits": "2.0.3",
-				"parse-asn1": "5.1.0"
+				"bn.js": "^4.1.1",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.2",
+				"elliptic": "^6.0.0",
+				"inherits": "^2.0.1",
+				"parse-asn1": "^5.0.0"
 			}
 		},
 		"browserify-zlib": {
@@ -496,7 +496,7 @@
 			"integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
 			"dev": true,
 			"requires": {
-				"pako": "1.0.6"
+				"pako": "~1.0.5"
 			}
 		},
 		"buf-compare": {
@@ -511,8 +511,8 @@
 			"integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
 			"dev": true,
 			"requires": {
-				"base64-js": "1.2.1",
-				"ieee754": "1.1.8"
+				"base64-js": "^1.0.2",
+				"ieee754": "^1.1.4"
 			}
 		},
 		"buffer-xor": {
@@ -545,7 +545,7 @@
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"dev": true,
 			"requires": {
-				"callsites": "0.2.0"
+				"callsites": "^0.2.0"
 			}
 		},
 		"callsites": {
@@ -566,8 +566,8 @@
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "2.1.1",
-				"map-obj": "1.0.1"
+				"camelcase": "^2.0.0",
+				"map-obj": "^1.0.0"
 			}
 		},
 		"capture-stack-trace": {
@@ -582,11 +582,11 @@
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -603,8 +603,8 @@
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"circular-json": {
@@ -625,7 +625,7 @@
 			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "1.0.1"
+				"restore-cursor": "^1.0.1"
 			}
 		},
 		"cli-width": {
@@ -652,7 +652,7 @@
 			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
@@ -667,10 +667,10 @@
 			"integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
 			"dev": true,
 			"requires": {
-				"convert-source-map": "1.1.3",
-				"inline-source-map": "0.6.2",
-				"lodash.memoize": "3.0.4",
-				"source-map": "0.5.7"
+				"convert-source-map": "~1.1.0",
+				"inline-source-map": "~0.6.0",
+				"lodash.memoize": "~3.0.3",
+				"source-map": "~0.5.3"
 			}
 		},
 		"commander": {
@@ -691,9 +691,9 @@
 			"integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.0.6",
-				"typedarray": "0.0.6"
+				"inherits": "~2.0.1",
+				"readable-stream": "~2.0.0",
+				"typedarray": "~0.0.5"
 			},
 			"dependencies": {
 				"readable-stream": {
@@ -702,12 +702,12 @@
 					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "0.10.31",
-						"util-deprecate": "1.0.2"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~1.0.6",
+						"string_decoder": "~0.10.x",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"string_decoder": {
@@ -724,12 +724,12 @@
 			"integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
 			"dev": true,
 			"requires": {
-				"dot-prop": "4.2.0",
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.1.0",
-				"unique-string": "1.0.0",
-				"write-file-atomic": "2.3.0",
-				"xdg-basedir": "3.0.0"
+				"dot-prop": "^4.1.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"unique-string": "^1.0.0",
+				"write-file-atomic": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
 			}
 		},
 		"console-browserify": {
@@ -738,7 +738,7 @@
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
 			"dev": true,
 			"requires": {
-				"date-now": "0.1.4"
+				"date-now": "^0.1.4"
 			}
 		},
 		"constants-browserify": {
@@ -765,8 +765,8 @@
 			"integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
 			"dev": true,
 			"requires": {
-				"buf-compare": "1.0.1",
-				"is-error": "2.2.1"
+				"buf-compare": "^1.0.0",
+				"is-error": "^2.2.0"
 			}
 		},
 		"core-js": {
@@ -787,8 +787,8 @@
 			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"elliptic": "6.4.0"
+				"bn.js": "^4.1.0",
+				"elliptic": "^6.0.0"
 			}
 		},
 		"create-error-class": {
@@ -797,7 +797,7 @@
 			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
 			"dev": true,
 			"requires": {
-				"capture-stack-trace": "1.0.0"
+				"capture-stack-trace": "^1.0.0"
 			}
 		},
 		"create-hash": {
@@ -806,10 +806,10 @@
 			"integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"sha.js": "2.4.9"
+				"cipher-base": "^1.0.1",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"sha.js": "^2.4.0"
 			}
 		},
 		"create-hmac": {
@@ -818,12 +818,12 @@
 			"integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
 			"dev": true,
 			"requires": {
-				"cipher-base": "1.0.4",
-				"create-hash": "1.1.3",
-				"inherits": "2.0.3",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.9"
+				"cipher-base": "^1.0.3",
+				"create-hash": "^1.1.0",
+				"inherits": "^2.0.1",
+				"ripemd160": "^2.0.0",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"cross-spawn": {
@@ -832,9 +832,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "4.1.1",
-				"shebang-command": "1.2.0",
-				"which": "1.3.0"
+				"lru-cache": "^4.0.1",
+				"shebang-command": "^1.2.0",
+				"which": "^1.2.9"
 			}
 		},
 		"crypto-browserify": {
@@ -843,16 +843,16 @@
 			"integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
 			"dev": true,
 			"requires": {
-				"browserify-cipher": "1.0.0",
-				"browserify-sign": "4.0.4",
-				"create-ecdh": "4.0.0",
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"diffie-hellman": "5.0.2",
-				"inherits": "2.0.3",
-				"pbkdf2": "3.0.14",
-				"public-encrypt": "4.0.0",
-				"randombytes": "2.0.5"
+				"browserify-cipher": "^1.0.0",
+				"browserify-sign": "^4.0.0",
+				"create-ecdh": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"create-hmac": "^1.1.0",
+				"diffie-hellman": "^5.0.0",
+				"inherits": "^2.0.1",
+				"pbkdf2": "^3.0.3",
+				"public-encrypt": "^4.0.0",
+				"randombytes": "^2.0.0"
 			}
 		},
 		"crypto-random-string": {
@@ -867,7 +867,7 @@
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"dev": true,
 			"requires": {
-				"array-find-index": "1.0.2"
+				"array-find-index": "^1.0.1"
 			}
 		},
 		"d": {
@@ -876,7 +876,7 @@
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"dev": true,
 			"requires": {
-				"es5-ext": "0.10.35"
+				"es5-ext": "^0.10.9"
 			}
 		},
 		"date-now": {
@@ -906,7 +906,7 @@
 			"integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
 			"dev": true,
 			"requires": {
-				"is-obj": "1.0.1"
+				"is-obj": "^1.0.0"
 			}
 		},
 		"deep-equal": {
@@ -933,7 +933,7 @@
 			"integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
 			"dev": true,
 			"requires": {
-				"core-assert": "0.2.1"
+				"core-assert": "^0.2.0"
 			}
 		},
 		"define-properties": {
@@ -942,8 +942,8 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "2.0.5",
-				"object-keys": "1.0.11"
+				"foreach": "^2.0.5",
+				"object-keys": "^1.0.8"
 			}
 		},
 		"defined": {
@@ -958,13 +958,13 @@
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 			"dev": true,
 			"requires": {
-				"globby": "5.0.0",
-				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.0",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"rimraf": "2.6.2"
+				"globby": "^5.0.0",
+				"is-path-cwd": "^1.0.0",
+				"is-path-in-cwd": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"rimraf": "^2.2.8"
 			},
 			"dependencies": {
 				"globby": {
@@ -973,12 +973,12 @@
 					"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 					"dev": true,
 					"requires": {
-						"array-union": "1.0.2",
-						"arrify": "1.0.1",
-						"glob": "7.1.2",
-						"object-assign": "4.1.1",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"array-union": "^1.0.1",
+						"arrify": "^1.0.0",
+						"glob": "^7.0.3",
+						"object-assign": "^4.0.1",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -989,10 +989,10 @@
 			"integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
 			"dev": true,
 			"requires": {
-				"JSONStream": "1.3.1",
-				"shasum": "1.0.2",
-				"subarg": "1.0.0",
-				"through2": "2.0.3"
+				"JSONStream": "^1.0.3",
+				"shasum": "^1.0.0",
+				"subarg": "^1.0.0",
+				"through2": "^2.0.0"
 			}
 		},
 		"des.js": {
@@ -1001,8 +1001,8 @@
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"detect-indent": {
@@ -1017,8 +1017,8 @@
 			"integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
 			"dev": true,
 			"requires": {
-				"acorn": "4.0.13",
-				"defined": "1.0.0"
+				"acorn": "^4.0.3",
+				"defined": "^1.0.0"
 			}
 		},
 		"diffie-hellman": {
@@ -1027,9 +1027,9 @@
 			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"miller-rabin": "4.0.1",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"miller-rabin": "^4.0.0",
+				"randombytes": "^2.0.0"
 			}
 		},
 		"doctrine": {
@@ -1038,8 +1038,8 @@
 			"integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
 			"dev": true,
 			"requires": {
-				"esutils": "2.0.2",
-				"isarray": "1.0.0"
+				"esutils": "^2.0.2",
+				"isarray": "^1.0.0"
 			}
 		},
 		"domain-browser": {
@@ -1054,7 +1054,7 @@
 			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
 			"dev": true,
 			"requires": {
-				"is-obj": "1.0.1"
+				"is-obj": "^1.0.0"
 			}
 		},
 		"duplexer2": {
@@ -1063,7 +1063,7 @@
 			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"duplexer3": {
@@ -1078,13 +1078,13 @@
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0",
-				"hash.js": "1.1.3",
-				"hmac-drbg": "1.0.1",
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
 			}
 		},
 		"enhance-visitors": {
@@ -1093,7 +1093,7 @@
 			"integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
 			"dev": true,
 			"requires": {
-				"lodash": "4.17.4"
+				"lodash": "^4.13.1"
 			}
 		},
 		"error-ex": {
@@ -1102,7 +1102,7 @@
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -1111,11 +1111,11 @@
 			"integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "1.1.1",
-				"function-bind": "1.1.1",
-				"has": "1.0.1",
-				"is-callable": "1.1.3",
-				"is-regex": "1.0.4"
+				"es-to-primitive": "^1.1.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.1",
+				"is-callable": "^1.1.3",
+				"is-regex": "^1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -1124,9 +1124,9 @@
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
-				"is-callable": "1.1.3",
-				"is-date-object": "1.0.1",
-				"is-symbol": "1.0.1"
+				"is-callable": "^1.1.1",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.1"
 			}
 		},
 		"es5-ext": {
@@ -1135,8 +1135,8 @@
 			"integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
 			"dev": true,
 			"requires": {
-				"es6-iterator": "2.0.3",
-				"es6-symbol": "3.1.1"
+				"es6-iterator": "~2.0.1",
+				"es6-symbol": "~3.1.1"
 			}
 		},
 		"es6-iterator": {
@@ -1145,9 +1145,9 @@
 			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-symbol": "3.1.1"
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
 			}
 		},
 		"es6-map": {
@@ -1156,12 +1156,12 @@
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
-				"es6-set": "0.1.5",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
+				"es6-set": "~0.1.5",
+				"es6-symbol": "~3.1.1",
+				"event-emitter": "~0.3.5"
 			}
 		},
 		"es6-set": {
@@ -1170,11 +1170,11 @@
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
 				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
+				"event-emitter": "~0.3.5"
 			}
 		},
 		"es6-symbol": {
@@ -1183,8 +1183,8 @@
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35"
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"es6-weak-map": {
@@ -1193,10 +1193,10 @@
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
-				"es6-symbol": "3.1.1"
+				"d": "1",
+				"es5-ext": "^0.10.14",
+				"es6-iterator": "^2.0.1",
+				"es6-symbol": "^3.1.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -1211,10 +1211,10 @@
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
 			"dev": true,
 			"requires": {
-				"es6-map": "0.1.5",
-				"es6-weak-map": "2.0.2",
-				"esrecurse": "4.2.0",
-				"estraverse": "4.2.0"
+				"es6-map": "^0.1.3",
+				"es6-weak-map": "^2.0.1",
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"eslint": {
@@ -1223,41 +1223,41 @@
 			"integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"chalk": "1.1.3",
-				"concat-stream": "1.5.2",
-				"debug": "2.6.9",
-				"doctrine": "2.0.0",
-				"escope": "3.6.0",
-				"espree": "3.5.1",
-				"esquery": "1.0.0",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"file-entry-cache": "2.0.0",
-				"glob": "7.1.2",
-				"globals": "9.18.0",
-				"ignore": "3.3.7",
-				"imurmurhash": "0.1.4",
-				"inquirer": "0.12.0",
-				"is-my-json-valid": "2.16.1",
-				"is-resolvable": "1.0.0",
-				"js-yaml": "3.10.0",
-				"json-stable-stringify": "1.0.1",
-				"levn": "0.3.0",
-				"lodash": "4.17.4",
-				"mkdirp": "0.5.1",
-				"natural-compare": "1.4.0",
-				"optionator": "0.8.2",
-				"path-is-inside": "1.0.2",
-				"pluralize": "1.2.1",
-				"progress": "1.1.8",
-				"require-uncached": "1.0.3",
-				"shelljs": "0.7.8",
-				"strip-bom": "3.0.0",
-				"strip-json-comments": "2.0.1",
-				"table": "3.8.3",
-				"text-table": "0.2.0",
-				"user-home": "2.0.0"
+				"babel-code-frame": "^6.16.0",
+				"chalk": "^1.1.3",
+				"concat-stream": "^1.5.2",
+				"debug": "^2.1.1",
+				"doctrine": "^2.0.0",
+				"escope": "^3.6.0",
+				"espree": "^3.4.0",
+				"esquery": "^1.0.0",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^2.0.0",
+				"glob": "^7.0.3",
+				"globals": "^9.14.0",
+				"ignore": "^3.2.0",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^0.12.0",
+				"is-my-json-valid": "^2.10.0",
+				"is-resolvable": "^1.0.0",
+				"js-yaml": "^3.5.1",
+				"json-stable-stringify": "^1.0.0",
+				"levn": "^0.3.0",
+				"lodash": "^4.0.0",
+				"mkdirp": "^0.5.0",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.8.2",
+				"path-is-inside": "^1.0.1",
+				"pluralize": "^1.2.1",
+				"progress": "^1.1.8",
+				"require-uncached": "^1.0.2",
+				"shelljs": "^0.7.5",
+				"strip-bom": "^3.0.0",
+				"strip-json-comments": "~2.0.1",
+				"table": "^3.7.8",
+				"text-table": "~0.2.0",
+				"user-home": "^2.0.0"
 			},
 			"dependencies": {
 				"json-stable-stringify": {
@@ -1266,7 +1266,7 @@
 					"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 					"dev": true,
 					"requires": {
-						"jsonify": "0.0.0"
+						"jsonify": "~0.0.0"
 					}
 				}
 			}
@@ -1283,11 +1283,11 @@
 			"integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "2.0.0",
-				"chalk": "2.3.0",
-				"log-symbols": "2.1.0",
-				"plur": "2.1.2",
-				"string-width": "2.1.1"
+				"ansi-escapes": "^2.0.0",
+				"chalk": "^2.1.0",
+				"log-symbols": "^2.0.0",
+				"plur": "^2.1.2",
+				"string-width": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -1308,7 +1308,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -1317,9 +1317,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -1334,8 +1334,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -1344,7 +1344,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -1355,8 +1355,8 @@
 			"integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"resolve": "1.5.0"
+				"debug": "^2.6.8",
+				"resolve": "^1.2.0"
 			}
 		},
 		"eslint-module-utils": {
@@ -1365,8 +1365,8 @@
 			"integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
 			"dev": true,
 			"requires": {
-				"debug": "2.6.9",
-				"pkg-dir": "1.0.0"
+				"debug": "^2.6.8",
+				"pkg-dir": "^1.0.0"
 			}
 		},
 		"eslint-plugin-ava": {
@@ -1375,14 +1375,14 @@
 			"integrity": "sha512-a4QDn9dyiFuwtQSQMDLDyklpf3/uQ7eT3+fVs0U/7cFPQF8IvhK3HpFCTd5iDGC7hljMDU9PFIUP+3Se4LV7fg==",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"deep-strict-equal": "0.2.0",
-				"enhance-visitors": "1.0.0",
-				"espree": "3.5.1",
-				"espurify": "1.7.0",
-				"import-modules": "1.1.0",
-				"multimatch": "2.1.0",
-				"pkg-up": "2.0.0"
+				"arrify": "^1.0.1",
+				"deep-strict-equal": "^0.2.0",
+				"enhance-visitors": "^1.0.0",
+				"espree": "^3.1.3",
+				"espurify": "^1.5.0",
+				"import-modules": "^1.1.0",
+				"multimatch": "^2.1.0",
+				"pkg-up": "^2.0.0"
 			}
 		},
 		"eslint-plugin-import": {
@@ -1391,16 +1391,16 @@
 			"integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "1.1.1",
-				"contains-path": "0.1.0",
-				"debug": "2.6.9",
+				"builtin-modules": "^1.1.1",
+				"contains-path": "^0.1.0",
+				"debug": "^2.6.8",
 				"doctrine": "1.5.0",
-				"eslint-import-resolver-node": "0.3.1",
-				"eslint-module-utils": "2.1.1",
-				"has": "1.0.1",
-				"lodash.cond": "4.5.2",
-				"minimatch": "3.0.4",
-				"read-pkg-up": "2.0.0"
+				"eslint-import-resolver-node": "^0.3.1",
+				"eslint-module-utils": "^2.1.1",
+				"has": "^1.0.1",
+				"lodash.cond": "^4.3.0",
+				"minimatch": "^3.0.3",
+				"read-pkg-up": "^2.0.0"
 			},
 			"dependencies": {
 				"doctrine": {
@@ -1409,8 +1409,8 @@
 					"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
 					"dev": true,
 					"requires": {
-						"esutils": "2.0.2",
-						"isarray": "1.0.0"
+						"esutils": "^2.0.2",
+						"isarray": "^1.0.0"
 					}
 				}
 			}
@@ -1421,10 +1421,10 @@
 			"integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
 			"dev": true,
 			"requires": {
-				"is-get-set-prop": "1.0.0",
-				"is-js-type": "2.0.0",
-				"is-obj-prop": "1.0.0",
-				"is-proto-prop": "1.0.0"
+				"is-get-set-prop": "^1.0.0",
+				"is-js-type": "^2.0.0",
+				"is-obj-prop": "^1.0.0",
+				"is-proto-prop": "^1.0.0"
 			}
 		},
 		"eslint-plugin-promise": {
@@ -1439,11 +1439,11 @@
 			"integrity": "sha1-md/+n0dzsEvDk1an/r1k3XACdLw=",
 			"dev": true,
 			"requires": {
-				"import-modules": "1.1.0",
-				"lodash.camelcase": "4.3.0",
-				"lodash.kebabcase": "4.1.1",
-				"lodash.snakecase": "4.1.1",
-				"lodash.upperfirst": "4.3.1"
+				"import-modules": "^1.1.0",
+				"lodash.camelcase": "^4.1.1",
+				"lodash.kebabcase": "^4.0.1",
+				"lodash.snakecase": "^4.0.1",
+				"lodash.upperfirst": "^4.2.0"
 			}
 		},
 		"espree": {
@@ -1452,8 +1452,8 @@
 			"integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
 			"dev": true,
 			"requires": {
-				"acorn": "5.2.1",
-				"acorn-jsx": "3.0.1"
+				"acorn": "^5.1.1",
+				"acorn-jsx": "^3.0.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -1476,7 +1476,7 @@
 			"integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
 			"dev": true,
 			"requires": {
-				"core-js": "2.5.1"
+				"core-js": "^2.0.0"
 			}
 		},
 		"esquery": {
@@ -1485,7 +1485,7 @@
 			"integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0"
+				"estraverse": "^4.0.0"
 			}
 		},
 		"esrecurse": {
@@ -1494,8 +1494,8 @@
 			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
 			"dev": true,
 			"requires": {
-				"estraverse": "4.2.0",
-				"object-assign": "4.1.1"
+				"estraverse": "^4.1.0",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"estraverse": {
@@ -1516,8 +1516,8 @@
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
 			"dev": true,
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35"
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"events": {
@@ -1532,8 +1532,8 @@
 			"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 			"dev": true,
 			"requires": {
-				"md5.js": "1.3.4",
-				"safe-buffer": "5.1.1"
+				"md5.js": "^1.3.4",
+				"safe-buffer": "^5.1.1"
 			}
 		},
 		"execa": {
@@ -1542,13 +1542,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			}
 		},
 		"exit-hook": {
@@ -1575,8 +1575,8 @@
 			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "1.0.5",
-				"object-assign": "4.1.1"
+				"escape-string-regexp": "^1.0.5",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"file-entry-cache": {
@@ -1585,8 +1585,8 @@
 			"integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
 			"dev": true,
 			"requires": {
-				"flat-cache": "1.3.0",
-				"object-assign": "4.1.1"
+				"flat-cache": "^1.2.1",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"find-up": {
@@ -1595,7 +1595,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "2.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"flat-cache": {
@@ -1604,10 +1604,10 @@
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"dev": true,
 			"requires": {
-				"circular-json": "0.3.3",
-				"del": "2.2.2",
-				"graceful-fs": "4.1.11",
-				"write": "0.2.1"
+				"circular-json": "^0.3.1",
+				"del": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"write": "^0.2.1"
 			}
 		},
 		"for-each": {
@@ -1616,7 +1616,7 @@
 			"integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
 			"dev": true,
 			"requires": {
-				"is-function": "1.0.1"
+				"is-function": "~1.0.0"
 			}
 		},
 		"foreach": {
@@ -1649,7 +1649,7 @@
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
 			"dev": true,
 			"requires": {
-				"is-property": "1.0.2"
+				"is-property": "^1.0.0"
 			}
 		},
 		"get-set-props": {
@@ -1676,12 +1676,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"global-dirs": {
@@ -1690,7 +1690,7 @@
 			"integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
 			"dev": true,
 			"requires": {
-				"ini": "1.3.4"
+				"ini": "^1.3.4"
 			}
 		},
 		"globals": {
@@ -1705,11 +1705,11 @@
 			"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 			"dev": true,
 			"requires": {
-				"array-union": "1.0.2",
-				"glob": "7.1.2",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"array-union": "^1.0.1",
+				"glob": "^7.0.3",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"got": {
@@ -1718,17 +1718,17 @@
 			"integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
 			"dev": true,
 			"requires": {
-				"create-error-class": "3.0.2",
-				"duplexer3": "0.1.4",
-				"get-stream": "3.0.0",
-				"is-redirect": "1.0.0",
-				"is-retry-allowed": "1.1.0",
-				"is-stream": "1.1.0",
-				"lowercase-keys": "1.0.0",
-				"safe-buffer": "5.1.1",
-				"timed-out": "4.0.1",
-				"unzip-response": "2.0.1",
-				"url-parse-lax": "1.0.0"
+				"create-error-class": "^3.0.0",
+				"duplexer3": "^0.1.4",
+				"get-stream": "^3.0.0",
+				"is-redirect": "^1.0.0",
+				"is-retry-allowed": "^1.0.0",
+				"is-stream": "^1.0.0",
+				"lowercase-keys": "^1.0.0",
+				"safe-buffer": "^5.0.1",
+				"timed-out": "^4.0.0",
+				"unzip-response": "^2.0.1",
+				"url-parse-lax": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -1743,7 +1743,7 @@
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"dev": true,
 			"requires": {
-				"function-bind": "1.1.1"
+				"function-bind": "^1.0.2"
 			}
 		},
 		"has-ansi": {
@@ -1752,7 +1752,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-flag": {
@@ -1767,7 +1767,7 @@
 			"integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3"
+				"inherits": "^2.0.1"
 			}
 		},
 		"hash.js": {
@@ -1776,8 +1776,8 @@
 			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"minimalistic-assert": "1.0.0"
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"hmac-drbg": {
@@ -1786,9 +1786,9 @@
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 			"dev": true,
 			"requires": {
-				"hash.js": "1.1.3",
-				"minimalistic-assert": "1.0.0",
-				"minimalistic-crypto-utils": "1.0.1"
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
 			}
 		},
 		"hosted-git-info": {
@@ -1845,7 +1845,7 @@
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"dev": true,
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"indexof": {
@@ -1860,8 +1860,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -1882,7 +1882,7 @@
 			"integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
 			"dev": true,
 			"requires": {
-				"source-map": "0.5.7"
+				"source-map": "~0.5.3"
 			}
 		},
 		"inquirer": {
@@ -1891,19 +1891,19 @@
 			"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "1.4.0",
-				"ansi-regex": "2.1.1",
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-width": "2.2.0",
-				"figures": "1.7.0",
-				"lodash": "4.17.4",
-				"readline2": "1.0.1",
-				"run-async": "0.1.0",
-				"rx-lite": "3.1.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"through": "2.3.8"
+				"ansi-escapes": "^1.1.0",
+				"ansi-regex": "^2.0.0",
+				"chalk": "^1.0.0",
+				"cli-cursor": "^1.0.1",
+				"cli-width": "^2.0.0",
+				"figures": "^1.3.5",
+				"lodash": "^4.3.0",
+				"readline2": "^1.0.1",
+				"run-async": "^0.1.0",
+				"rx-lite": "^3.1.2",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.0",
+				"through": "^2.3.6"
 			}
 		},
 		"insert-module-globals": {
@@ -1912,14 +1912,14 @@
 			"integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
 			"dev": true,
 			"requires": {
-				"JSONStream": "1.3.1",
-				"combine-source-map": "0.7.2",
-				"concat-stream": "1.5.2",
-				"is-buffer": "1.1.6",
-				"lexical-scope": "1.2.0",
-				"process": "0.11.10",
-				"through2": "2.0.3",
-				"xtend": "4.0.1"
+				"JSONStream": "^1.0.3",
+				"combine-source-map": "~0.7.1",
+				"concat-stream": "~1.5.1",
+				"is-buffer": "^1.1.0",
+				"lexical-scope": "^1.2.0",
+				"process": "~0.11.0",
+				"through2": "^2.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"interpret": {
@@ -1952,7 +1952,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-callable": {
@@ -1979,7 +1979,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -1988,7 +1988,7 @@
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-function": {
@@ -2003,8 +2003,8 @@
 			"integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
 			"dev": true,
 			"requires": {
-				"get-set-props": "0.1.0",
-				"lowercase-keys": "1.0.0"
+				"get-set-props": "^0.1.0",
+				"lowercase-keys": "^1.0.0"
 			}
 		},
 		"is-installed-globally": {
@@ -2013,8 +2013,8 @@
 			"integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
 			"dev": true,
 			"requires": {
-				"global-dirs": "0.1.0",
-				"is-path-inside": "1.0.0"
+				"global-dirs": "^0.1.0",
+				"is-path-inside": "^1.0.0"
 			}
 		},
 		"is-js-type": {
@@ -2023,7 +2023,7 @@
 			"integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
 			"dev": true,
 			"requires": {
-				"js-types": "1.0.0"
+				"js-types": "^1.0.0"
 			}
 		},
 		"is-my-json-valid": {
@@ -2032,10 +2032,10 @@
 			"integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
 			"dev": true,
 			"requires": {
-				"generate-function": "2.0.0",
-				"generate-object-property": "1.2.0",
-				"jsonpointer": "4.0.1",
-				"xtend": "4.0.1"
+				"generate-function": "^2.0.0",
+				"generate-object-property": "^1.1.0",
+				"jsonpointer": "^4.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"is-npm": {
@@ -2056,8 +2056,8 @@
 			"integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "1.0.0",
-				"obj-props": "1.1.0"
+				"lowercase-keys": "^1.0.0",
+				"obj-props": "^1.0.0"
 			}
 		},
 		"is-path-cwd": {
@@ -2072,7 +2072,7 @@
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
 			"dev": true,
 			"requires": {
-				"is-path-inside": "1.0.0"
+				"is-path-inside": "^1.0.0"
 			}
 		},
 		"is-path-inside": {
@@ -2081,7 +2081,7 @@
 			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
 			"dev": true,
 			"requires": {
-				"path-is-inside": "1.0.2"
+				"path-is-inside": "^1.0.1"
 			}
 		},
 		"is-plain-obj": {
@@ -2102,8 +2102,8 @@
 			"integrity": "sha1-s5UflcCJkk+11PzaZUKrPoPisiA=",
 			"dev": true,
 			"requires": {
-				"lowercase-keys": "1.0.0",
-				"proto-props": "0.2.1"
+				"lowercase-keys": "^1.0.0",
+				"proto-props": "^0.2.0"
 			}
 		},
 		"is-redirect": {
@@ -2118,7 +2118,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "1.0.1"
+				"has": "^1.0.1"
 			}
 		},
 		"is-resolvable": {
@@ -2127,7 +2127,7 @@
 			"integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
 			"dev": true,
 			"requires": {
-				"tryit": "1.0.3"
+				"tryit": "^1.0.1"
 			}
 		},
 		"is-retry-allowed": {
@@ -2184,8 +2184,8 @@
 			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
 			"dev": true,
 			"requires": {
-				"argparse": "1.0.9",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			}
 		},
 		"json-stable-stringify": {
@@ -2194,7 +2194,7 @@
 			"integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
 			"dev": true,
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"jsonify": {
@@ -2221,9 +2221,9 @@
 			"integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"isarray": "0.0.1",
-				"stream-splicer": "2.0.0"
+				"inherits": "^2.0.1",
+				"isarray": "~0.0.1",
+				"stream-splicer": "^2.0.0"
 			},
 			"dependencies": {
 				"isarray": {
@@ -2240,7 +2240,7 @@
 			"integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
 			"dev": true,
 			"requires": {
-				"package-json": "4.0.1"
+				"package-json": "^4.0.0"
 			}
 		},
 		"levn": {
@@ -2249,8 +2249,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"lexical-scope": {
@@ -2259,7 +2259,7 @@
 			"integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
 			"dev": true,
 			"requires": {
-				"astw": "2.2.0"
+				"astw": "^2.0.0"
 			}
 		},
 		"load-json-file": {
@@ -2268,10 +2268,10 @@
 			"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"strip-bom": "3.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"strip-bom": "^3.0.0"
 			}
 		},
 		"locate-path": {
@@ -2280,8 +2280,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			}
 		},
 		"lodash": {
@@ -2343,7 +2343,7 @@
 			"integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.0"
+				"chalk": "^2.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -2352,7 +2352,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -2361,9 +2361,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				}
 			}
@@ -2374,8 +2374,8 @@
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"dev": true,
 			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"lowercase-keys": {
@@ -2390,8 +2390,8 @@
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"make-dir": {
@@ -2400,7 +2400,7 @@
 			"integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
 			"dev": true,
 			"requires": {
-				"pify": "3.0.0"
+				"pify": "^3.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -2423,8 +2423,8 @@
 			"integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
 			"dev": true,
 			"requires": {
-				"hash-base": "3.0.4",
-				"inherits": "2.0.3"
+				"hash-base": "^3.0.0",
+				"inherits": "^2.0.1"
 			},
 			"dependencies": {
 				"hash-base": {
@@ -2433,8 +2433,8 @@
 					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 					"dev": true,
 					"requires": {
-						"inherits": "2.0.3",
-						"safe-buffer": "5.1.1"
+						"inherits": "^2.0.1",
+						"safe-buffer": "^5.0.1"
 					}
 				}
 			}
@@ -2445,16 +2445,16 @@
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
 			"requires": {
-				"camelcase-keys": "2.1.0",
-				"decamelize": "1.2.0",
-				"loud-rejection": "1.6.0",
-				"map-obj": "1.0.1",
-				"minimist": "1.2.0",
-				"normalize-package-data": "2.4.0",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"redent": "1.0.0",
-				"trim-newlines": "1.0.0"
+				"camelcase-keys": "^2.0.0",
+				"decamelize": "^1.1.2",
+				"loud-rejection": "^1.0.0",
+				"map-obj": "^1.0.1",
+				"minimist": "^1.1.3",
+				"normalize-package-data": "^2.3.4",
+				"object-assign": "^4.0.1",
+				"read-pkg-up": "^1.0.1",
+				"redent": "^1.0.0",
+				"trim-newlines": "^1.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -2463,8 +2463,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"load-json-file": {
@@ -2473,11 +2473,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1",
-						"strip-bom": "2.0.0"
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^2.2.0",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0",
+						"strip-bom": "^2.0.0"
 					}
 				},
 				"path-exists": {
@@ -2486,7 +2486,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-type": {
@@ -2495,9 +2495,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"pify": "2.3.0",
-						"pinkie-promise": "2.0.1"
+						"graceful-fs": "^4.1.2",
+						"pify": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"read-pkg": {
@@ -2506,9 +2506,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "1.1.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "1.1.0"
+						"load-json-file": "^1.0.0",
+						"normalize-package-data": "^2.3.2",
+						"path-type": "^1.0.0"
 					}
 				},
 				"read-pkg-up": {
@@ -2517,8 +2517,8 @@
 					"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 					"dev": true,
 					"requires": {
-						"find-up": "1.1.2",
-						"read-pkg": "1.1.0"
+						"find-up": "^1.0.0",
+						"read-pkg": "^1.0.0"
 					}
 				},
 				"strip-bom": {
@@ -2527,7 +2527,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "0.2.1"
+						"is-utf8": "^0.2.0"
 					}
 				}
 			}
@@ -2538,8 +2538,8 @@
 			"integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"brorand": "1.1.0"
+				"bn.js": "^4.0.0",
+				"brorand": "^1.0.1"
 			}
 		},
 		"minimalistic-assert": {
@@ -2560,7 +2560,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -2592,21 +2592,21 @@
 			"integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
 			"dev": true,
 			"requires": {
-				"JSONStream": "1.3.1",
-				"browser-resolve": "1.11.2",
-				"cached-path-relative": "1.0.1",
-				"concat-stream": "1.5.2",
-				"defined": "1.0.0",
-				"detective": "4.5.0",
-				"duplexer2": "0.1.4",
-				"inherits": "2.0.3",
-				"parents": "1.0.1",
-				"readable-stream": "2.3.3",
-				"resolve": "1.5.0",
-				"stream-combiner2": "1.1.1",
-				"subarg": "1.0.0",
-				"through2": "2.0.3",
-				"xtend": "4.0.1"
+				"JSONStream": "^1.0.3",
+				"browser-resolve": "^1.7.0",
+				"cached-path-relative": "^1.0.0",
+				"concat-stream": "~1.5.0",
+				"defined": "^1.0.0",
+				"detective": "^4.0.0",
+				"duplexer2": "^0.1.2",
+				"inherits": "^2.0.1",
+				"parents": "^1.0.0",
+				"readable-stream": "^2.0.2",
+				"resolve": "^1.1.3",
+				"stream-combiner2": "^1.1.1",
+				"subarg": "^1.0.0",
+				"through2": "^2.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"ms": {
@@ -2621,10 +2621,10 @@
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"dev": true,
 			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
+				"array-differ": "^1.0.0",
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"minimatch": "^3.0.0"
 			}
 		},
 		"mute-stream": {
@@ -2644,7 +2644,7 @@
 			"resolved": "https://registry.npmjs.org/nlcst-is-literal/-/nlcst-is-literal-1.1.1.tgz",
 			"integrity": "sha1-jY8R2r/+v3UmwTqAZ05pZCG+yus=",
 			"requires": {
-				"nlcst-to-string": "2.0.1"
+				"nlcst-to-string": "^2.0.0"
 			}
 		},
 		"nlcst-normalize": {
@@ -2652,7 +2652,7 @@
 			"resolved": "https://registry.npmjs.org/nlcst-normalize/-/nlcst-normalize-2.1.1.tgz",
 			"integrity": "sha1-1+1DIxLPRWM1cvgL6IAjg/86Bww=",
 			"requires": {
-				"nlcst-to-string": "2.0.1"
+				"nlcst-to-string": "^2.0.0"
 			}
 		},
 		"nlcst-search": {
@@ -2660,9 +2660,9 @@
 			"resolved": "https://registry.npmjs.org/nlcst-search/-/nlcst-search-1.4.2.tgz",
 			"integrity": "sha1-vuGTSOkYAUufaCzGpcatnwjxF80=",
 			"requires": {
-				"nlcst-is-literal": "1.1.1",
-				"nlcst-normalize": "2.1.1",
-				"unist-util-visit": "1.1.3"
+				"nlcst-is-literal": "^1.1.0",
+				"nlcst-normalize": "^2.1.0",
+				"unist-util-visit": "^1.0.0"
 			}
 		},
 		"nlcst-to-string": {
@@ -2676,10 +2676,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "2.5.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.4.1",
-				"validate-npm-package-license": "3.0.1"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -2688,7 +2688,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -2727,7 +2727,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
@@ -2742,12 +2742,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			}
 		},
 		"os-browserify": {
@@ -2780,7 +2780,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "1.1.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"package-json": {
@@ -2789,10 +2789,10 @@
 			"integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
 			"dev": true,
 			"requires": {
-				"got": "6.7.1",
-				"registry-auth-token": "3.3.1",
-				"registry-url": "3.1.0",
-				"semver": "5.4.1"
+				"got": "^6.7.1",
+				"registry-auth-token": "^3.0.1",
+				"registry-url": "^3.0.3",
+				"semver": "^5.1.0"
 			}
 		},
 		"pako": {
@@ -2807,7 +2807,7 @@
 			"integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
 			"dev": true,
 			"requires": {
-				"path-platform": "0.11.15"
+				"path-platform": "~0.11.15"
 			}
 		},
 		"parse-asn1": {
@@ -2816,11 +2816,11 @@
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
 			"dev": true,
 			"requires": {
-				"asn1.js": "4.9.1",
-				"browserify-aes": "1.1.1",
-				"create-hash": "1.1.3",
-				"evp_bytestokey": "1.0.3",
-				"pbkdf2": "3.0.14"
+				"asn1.js": "^4.0.0",
+				"browserify-aes": "^1.0.0",
+				"create-hash": "^1.1.0",
+				"evp_bytestokey": "^1.0.0",
+				"pbkdf2": "^3.0.3"
 			}
 		},
 		"parse-json": {
@@ -2829,7 +2829,7 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"parse-latin": {
@@ -2838,9 +2838,9 @@
 			"integrity": "sha512-mLNys0aA6v2bt4+/dmM5F7tRrLZ45Wg19++xr8iCo813NdurhIAiZpcXwvb086DvVGwSkcGUmz+AkbthMVVNyg==",
 			"dev": true,
 			"requires": {
-				"nlcst-to-string": "2.0.1",
-				"unist-util-modify-children": "1.1.1",
-				"unist-util-visit-children": "1.1.1"
+				"nlcst-to-string": "^2.0.0",
+				"unist-util-modify-children": "^1.0.0",
+				"unist-util-visit-children": "^1.0.0"
 			}
 		},
 		"path-browserify": {
@@ -2891,7 +2891,7 @@
 			"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
 			"dev": true,
 			"requires": {
-				"pify": "2.3.0"
+				"pify": "^2.0.0"
 			}
 		},
 		"pbkdf2": {
@@ -2900,11 +2900,11 @@
 			"integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
 			"dev": true,
 			"requires": {
-				"create-hash": "1.1.3",
-				"create-hmac": "1.1.6",
-				"ripemd160": "2.0.1",
-				"safe-buffer": "5.1.1",
-				"sha.js": "2.4.9"
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4",
+				"ripemd160": "^2.0.1",
+				"safe-buffer": "^5.0.1",
+				"sha.js": "^2.4.8"
 			}
 		},
 		"pify": {
@@ -2925,7 +2925,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"pkg-conf": {
@@ -2934,8 +2934,8 @@
 			"integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0",
-				"load-json-file": "2.0.0"
+				"find-up": "^2.0.0",
+				"load-json-file": "^2.0.0"
 			}
 		},
 		"pkg-dir": {
@@ -2944,7 +2944,7 @@
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
 			"dev": true,
 			"requires": {
-				"find-up": "1.1.2"
+				"find-up": "^1.0.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -2953,8 +2953,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "2.1.0",
-						"pinkie-promise": "2.0.1"
+						"path-exists": "^2.0.0",
+						"pinkie-promise": "^2.0.0"
 					}
 				},
 				"path-exists": {
@@ -2963,7 +2963,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -2974,7 +2974,7 @@
 			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0"
+				"find-up": "^2.1.0"
 			}
 		},
 		"plur": {
@@ -2983,7 +2983,7 @@
 			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
 			"dev": true,
 			"requires": {
-				"irregular-plurals": "1.4.0"
+				"irregular-plurals": "^1.0.0"
 			}
 		},
 		"pluralize": {
@@ -3040,11 +3040,11 @@
 			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
 			"dev": true,
 			"requires": {
-				"bn.js": "4.11.8",
-				"browserify-rsa": "4.0.1",
-				"create-hash": "1.1.3",
-				"parse-asn1": "5.1.0",
-				"randombytes": "2.0.5"
+				"bn.js": "^4.1.0",
+				"browserify-rsa": "^4.0.0",
+				"create-hash": "^1.1.0",
+				"parse-asn1": "^5.0.0",
+				"randombytes": "^2.0.1"
 			}
 		},
 		"punycode": {
@@ -3076,7 +3076,7 @@
 			"integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"rc": {
@@ -3085,10 +3085,10 @@
 			"integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
 			"dev": true,
 			"requires": {
-				"deep-extend": "0.4.2",
-				"ini": "1.3.4",
-				"minimist": "1.2.0",
-				"strip-json-comments": "2.0.1"
+				"deep-extend": "~0.4.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
 			}
 		},
 		"read-only-stream": {
@@ -3097,7 +3097,7 @@
 			"integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3"
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"read-pkg": {
@@ -3106,9 +3106,9 @@
 			"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "2.0.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "2.0.0"
+				"load-json-file": "^2.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^2.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -3117,8 +3117,8 @@
 			"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
 			"dev": true,
 			"requires": {
-				"find-up": "2.1.0",
-				"read-pkg": "2.0.0"
+				"find-up": "^2.0.0",
+				"read-pkg": "^2.0.0"
 			}
 		},
 		"readable-stream": {
@@ -3127,13 +3127,13 @@
 			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
 			"dev": true,
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~1.0.6",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.0.3",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readline2": {
@@ -3142,8 +3142,8 @@
 			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
 			"dev": true,
 			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
 				"mute-stream": "0.0.5"
 			}
 		},
@@ -3153,7 +3153,7 @@
 			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
 			"dev": true,
 			"requires": {
-				"resolve": "1.5.0"
+				"resolve": "^1.1.6"
 			}
 		},
 		"redent": {
@@ -3162,8 +3162,8 @@
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"dev": true,
 			"requires": {
-				"indent-string": "2.1.0",
-				"strip-indent": "1.0.1"
+				"indent-string": "^2.1.0",
+				"strip-indent": "^1.0.1"
 			}
 		},
 		"registry-auth-token": {
@@ -3172,8 +3172,8 @@
 			"integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
 			"dev": true,
 			"requires": {
-				"rc": "1.2.2",
-				"safe-buffer": "5.1.1"
+				"rc": "^1.1.6",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"registry-url": {
@@ -3182,7 +3182,7 @@
 			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
 			"dev": true,
 			"requires": {
-				"rc": "1.2.2"
+				"rc": "^1.0.1"
 			}
 		},
 		"repeat-string": {
@@ -3197,7 +3197,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"replace-ext": {
@@ -3212,8 +3212,8 @@
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"dev": true,
 			"requires": {
-				"caller-path": "0.1.0",
-				"resolve-from": "1.0.1"
+				"caller-path": "^0.1.0",
+				"resolve-from": "^1.0.0"
 			},
 			"dependencies": {
 				"resolve-from": {
@@ -3230,7 +3230,7 @@
 			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
 			"dev": true,
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.5"
 			}
 		},
 		"resolve-cwd": {
@@ -3239,7 +3239,7 @@
 			"integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "2.0.0"
+				"resolve-from": "^2.0.0"
 			}
 		},
 		"resolve-from": {
@@ -3254,8 +3254,8 @@
 			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 			"dev": true,
 			"requires": {
-				"exit-hook": "1.1.1",
-				"onetime": "1.1.0"
+				"exit-hook": "^1.0.0",
+				"onetime": "^1.0.0"
 			}
 		},
 		"resumer": {
@@ -3264,7 +3264,7 @@
 			"integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
 			"dev": true,
 			"requires": {
-				"through": "2.3.8"
+				"through": "~2.3.4"
 			}
 		},
 		"retext": {
@@ -3273,9 +3273,9 @@
 			"integrity": "sha1-XZAYxKZ31hA8FCNi129Q6x05i/Y=",
 			"dev": true,
 			"requires": {
-				"retext-latin": "2.0.0",
-				"retext-stringify": "2.0.0",
-				"unified": "6.1.5"
+				"retext-latin": "^2.0.0",
+				"retext-stringify": "^2.0.0",
+				"unified": "^6.0.0"
 			}
 		},
 		"retext-latin": {
@@ -3284,8 +3284,8 @@
 			"integrity": "sha1-sRvWyukRP6YpMCKkUnzXByIaxLY=",
 			"dev": true,
 			"requires": {
-				"parse-latin": "4.1.0",
-				"unherit": "1.1.0"
+				"parse-latin": "^4.0.0",
+				"unherit": "^1.0.4"
 			}
 		},
 		"retext-stringify": {
@@ -3294,7 +3294,7 @@
 			"integrity": "sha1-ACOPrMVJH1vNxYlwOkZY2y5UQVs=",
 			"dev": true,
 			"requires": {
-				"nlcst-to-string": "2.0.1"
+				"nlcst-to-string": "^2.0.0"
 			}
 		},
 		"rimraf": {
@@ -3303,7 +3303,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2"
+				"glob": "^7.0.5"
 			}
 		},
 		"ripemd160": {
@@ -3312,8 +3312,8 @@
 			"integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
 			"dev": true,
 			"requires": {
-				"hash-base": "2.0.2",
-				"inherits": "2.0.3"
+				"hash-base": "^2.0.0",
+				"inherits": "^2.0.1"
 			}
 		},
 		"run-async": {
@@ -3322,7 +3322,7 @@
 			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
 			"dev": true,
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.3.0"
 			}
 		},
 		"rx-lite": {
@@ -3349,7 +3349,7 @@
 			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
 			"dev": true,
 			"requires": {
-				"semver": "5.4.1"
+				"semver": "^5.0.3"
 			}
 		},
 		"sha.js": {
@@ -3358,8 +3358,8 @@
 			"integrity": "sha512-G8zektVqbiPHrylgew9Zg1VRB1L/DtXNUVAM6q4QLy8NE3qtHlFXTf8VLL4k1Yl6c7NMjtZUTdXV+X44nFaT6A==",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"safe-buffer": "5.1.1"
+				"inherits": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"shasum": {
@@ -3368,8 +3368,8 @@
 			"integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
 			"dev": true,
 			"requires": {
-				"json-stable-stringify": "0.0.1",
-				"sha.js": "2.4.9"
+				"json-stable-stringify": "~0.0.0",
+				"sha.js": "~2.4.4"
 			}
 		},
 		"shebang-command": {
@@ -3378,7 +3378,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -3393,10 +3393,10 @@
 			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
 			"dev": true,
 			"requires": {
-				"array-filter": "0.0.1",
-				"array-map": "0.0.0",
-				"array-reduce": "0.0.0",
-				"jsonify": "0.0.0"
+				"array-filter": "~0.0.0",
+				"array-map": "~0.0.0",
+				"array-reduce": "~0.0.0",
+				"jsonify": "~0.0.0"
 			}
 		},
 		"shelljs": {
@@ -3405,9 +3405,9 @@
 			"integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
 			"dev": true,
 			"requires": {
-				"glob": "7.1.2",
-				"interpret": "1.0.4",
-				"rechoir": "0.6.2"
+				"glob": "^7.0.0",
+				"interpret": "^1.0.0",
+				"rechoir": "^0.6.2"
 			}
 		},
 		"signal-exit": {
@@ -3434,7 +3434,7 @@
 			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
 			"dev": true,
 			"requires": {
-				"is-plain-obj": "1.1.0"
+				"is-plain-obj": "^1.0.0"
 			}
 		},
 		"source-map": {
@@ -3449,7 +3449,7 @@
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
 			"dev": true,
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-license-ids": "^1.0.2"
 			}
 		},
 		"spdx-expression-parse": {
@@ -3476,8 +3476,8 @@
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "~2.0.1",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"stream-combiner2": {
@@ -3486,8 +3486,8 @@
 			"integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
 			"dev": true,
 			"requires": {
-				"duplexer2": "0.1.4",
-				"readable-stream": "2.3.3"
+				"duplexer2": "~0.1.0",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"stream-http": {
@@ -3496,11 +3496,11 @@
 			"integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
 			"dev": true,
 			"requires": {
-				"builtin-status-codes": "3.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"to-arraybuffer": "1.0.1",
-				"xtend": "4.0.1"
+				"builtin-status-codes": "^3.0.0",
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.2.6",
+				"to-arraybuffer": "^1.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"stream-splicer": {
@@ -3509,8 +3509,8 @@
 			"integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3"
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.2"
 			}
 		},
 		"string-width": {
@@ -3519,9 +3519,9 @@
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"dev": true,
 			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"strip-ansi": "3.0.1"
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
 			}
 		},
 		"string.prototype.trim": {
@@ -3530,9 +3530,9 @@
 			"integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
 			"dev": true,
 			"requires": {
-				"define-properties": "1.1.2",
-				"es-abstract": "1.9.0",
-				"function-bind": "1.1.1"
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.0",
+				"function-bind": "^1.0.2"
 			}
 		},
 		"string_decoder": {
@@ -3541,7 +3541,7 @@
 			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"strip-ansi": {
@@ -3550,7 +3550,7 @@
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
@@ -3571,7 +3571,7 @@
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"dev": true,
 			"requires": {
-				"get-stdin": "4.0.1"
+				"get-stdin": "^4.0.1"
 			},
 			"dependencies": {
 				"get-stdin": {
@@ -3594,7 +3594,7 @@
 			"integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
 			"dev": true,
 			"requires": {
-				"minimist": "1.2.0"
+				"minimist": "^1.1.0"
 			}
 		},
 		"supports-color": {
@@ -3603,7 +3603,7 @@
 			"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 			"dev": true,
 			"requires": {
-				"has-flag": "2.0.0"
+				"has-flag": "^2.0.0"
 			}
 		},
 		"syntax-error": {
@@ -3612,7 +3612,7 @@
 			"integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
 			"dev": true,
 			"requires": {
-				"acorn": "4.0.13"
+				"acorn": "^4.0.3"
 			}
 		},
 		"table": {
@@ -3621,12 +3621,12 @@
 			"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
 			"dev": true,
 			"requires": {
-				"ajv": "4.11.8",
-				"ajv-keywords": "1.5.1",
-				"chalk": "1.1.3",
-				"lodash": "4.17.4",
+				"ajv": "^4.7.0",
+				"ajv-keywords": "^1.0.0",
+				"chalk": "^1.1.1",
+				"lodash": "^4.0.0",
 				"slice-ansi": "0.0.4",
-				"string-width": "2.1.1"
+				"string-width": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -3647,8 +3647,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -3657,7 +3657,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -3668,19 +3668,19 @@
 			"integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
 			"dev": true,
 			"requires": {
-				"deep-equal": "1.0.1",
-				"defined": "1.0.0",
-				"for-each": "0.3.2",
-				"function-bind": "1.1.1",
-				"glob": "7.1.2",
-				"has": "1.0.1",
-				"inherits": "2.0.3",
-				"minimist": "1.2.0",
-				"object-inspect": "1.3.0",
-				"resolve": "1.4.0",
-				"resumer": "0.0.0",
-				"string.prototype.trim": "1.1.2",
-				"through": "2.3.8"
+				"deep-equal": "~1.0.1",
+				"defined": "~1.0.0",
+				"for-each": "~0.3.2",
+				"function-bind": "~1.1.0",
+				"glob": "~7.1.2",
+				"has": "~1.0.1",
+				"inherits": "~2.0.3",
+				"minimist": "~1.2.0",
+				"object-inspect": "~1.3.0",
+				"resolve": "~1.4.0",
+				"resumer": "~0.0.0",
+				"string.prototype.trim": "~1.1.2",
+				"through": "~2.3.8"
 			},
 			"dependencies": {
 				"resolve": {
@@ -3689,7 +3689,7 @@
 					"integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
 					"dev": true,
 					"requires": {
-						"path-parse": "1.0.5"
+						"path-parse": "^1.0.5"
 					}
 				}
 			}
@@ -3700,7 +3700,7 @@
 			"integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
 			"dev": true,
 			"requires": {
-				"execa": "0.7.0"
+				"execa": "^0.7.0"
 			}
 		},
 		"text-table": {
@@ -3727,8 +3727,8 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "2.3.3",
-				"xtend": "4.0.1"
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
 			}
 		},
 		"timed-out": {
@@ -3743,7 +3743,7 @@
 			"integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
 			"dev": true,
 			"requires": {
-				"process": "0.11.10"
+				"process": "~0.11.0"
 			}
 		},
 		"to-arraybuffer": {
@@ -3758,8 +3758,8 @@
 			"integrity": "sha512-o8o2CXU2LDxh4OsvG9bGRXkIhcvk+bWKqWQECLcjfMNy2b8rl4kuFAZeTcPM5obK1mrvQ4iS3AcdopFDluq1jQ==",
 			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.6",
-				"vfile": "2.2.0"
+				"is-buffer": "^1.1.4",
+				"vfile": "^2.0.0"
 			}
 		},
 		"trim-newlines": {
@@ -3792,7 +3792,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"typedarray": {
@@ -3807,8 +3807,8 @@
 			"integrity": "sha512-/rseyxEKEVMBo8279lqpoJgD6C/i/CIi+9TJDvWmb+Xo6mqMKwjA8Io3IMHlcXQzj99feR6zrN8m3wqqvm/nYA==",
 			"dev": true,
 			"requires": {
-				"commander": "2.11.0",
-				"source-map": "0.6.1"
+				"commander": "~2.11.0",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -3831,8 +3831,8 @@
 			"integrity": "sha1-a5qu379z3xdWrZ4xbdmBiFhAzX0=",
 			"dev": true,
 			"requires": {
-				"inherits": "2.0.3",
-				"xtend": "4.0.1"
+				"inherits": "^2.0.1",
+				"xtend": "^4.0.1"
 			}
 		},
 		"unified": {
@@ -3841,13 +3841,13 @@
 			"integrity": "sha1-cWk3hyYhpjE15iztLzrGoGPG+4c=",
 			"dev": true,
 			"requires": {
-				"bail": "1.0.2",
-				"extend": "3.0.1",
-				"is-plain-obj": "1.1.0",
-				"trough": "1.0.1",
-				"vfile": "2.2.0",
-				"x-is-function": "1.0.4",
-				"x-is-string": "0.1.0"
+				"bail": "^1.0.0",
+				"extend": "^3.0.0",
+				"is-plain-obj": "^1.1.0",
+				"trough": "^1.0.0",
+				"vfile": "^2.0.0",
+				"x-is-function": "^1.0.4",
+				"x-is-string": "^0.1.0"
 			}
 		},
 		"unique-string": {
@@ -3856,7 +3856,7 @@
 			"integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
 			"dev": true,
 			"requires": {
-				"crypto-random-string": "1.0.0"
+				"crypto-random-string": "^1.0.0"
 			}
 		},
 		"unist-util-find-before": {
@@ -3864,7 +3864,7 @@
 			"resolved": "https://registry.npmjs.org/unist-util-find-before/-/unist-util-find-before-2.0.1.tgz",
 			"integrity": "sha1-FfmqstmwZl+Sz5IFHwpLSM81IZA=",
 			"requires": {
-				"unist-util-is": "2.1.1"
+				"unist-util-is": "^2.0.0"
 			}
 		},
 		"unist-util-is": {
@@ -3878,7 +3878,7 @@
 			"integrity": "sha1-ZtfmpEnm9nIguXarPLi166w55R0=",
 			"dev": true,
 			"requires": {
-				"array-iterate": "1.1.1"
+				"array-iterate": "^1.0.0"
 			}
 		},
 		"unist-util-stringify-position": {
@@ -3910,15 +3910,15 @@
 			"integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
 			"dev": true,
 			"requires": {
-				"boxen": "1.2.2",
-				"chalk": "2.3.0",
-				"configstore": "3.1.1",
-				"import-lazy": "2.1.0",
-				"is-installed-globally": "0.1.0",
-				"is-npm": "1.0.0",
-				"latest-version": "3.1.0",
-				"semver-diff": "2.1.0",
-				"xdg-basedir": "3.0.0"
+				"boxen": "^1.2.1",
+				"chalk": "^2.0.1",
+				"configstore": "^3.0.0",
+				"import-lazy": "^2.1.0",
+				"is-installed-globally": "^0.1.0",
+				"is-npm": "^1.0.0",
+				"latest-version": "^3.0.0",
+				"semver-diff": "^2.0.0",
+				"xdg-basedir": "^3.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -3927,7 +3927,7 @@
 					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.0"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
@@ -3936,9 +3936,9 @@
 					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.1.0",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^4.0.0"
 					}
 				}
 			}
@@ -3967,7 +3967,7 @@
 			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
 			"dev": true,
 			"requires": {
-				"prepend-http": "1.0.4"
+				"prepend-http": "^1.0.1"
 			}
 		},
 		"user-home": {
@@ -3976,7 +3976,7 @@
 			"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "1.0.2"
+				"os-homedir": "^1.0.0"
 			}
 		},
 		"util": {
@@ -4008,8 +4008,8 @@
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "~1.0.0",
+				"spdx-expression-parse": "~1.0.0"
 			}
 		},
 		"vfile": {
@@ -4018,9 +4018,9 @@
 			"integrity": "sha1-zkek+zNZIrIz5TXbD32BIdj87U4=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "1.1.6",
+				"is-buffer": "^1.1.4",
 				"replace-ext": "1.0.0",
-				"unist-util-stringify-position": "1.1.1"
+				"unist-util-stringify-position": "^1.0.0"
 			}
 		},
 		"vfile-reporter": {
@@ -4029,11 +4029,11 @@
 			"integrity": "sha1-6m8K4TQvSEFXOYXgX5QXNvJ96do=",
 			"dev": true,
 			"requires": {
-				"repeat-string": "1.6.1",
-				"string-width": "1.0.2",
-				"supports-color": "4.5.0",
-				"unist-util-stringify-position": "1.1.1",
-				"vfile-statistics": "1.1.0"
+				"repeat-string": "^1.5.0",
+				"string-width": "^1.0.0",
+				"supports-color": "^4.1.0",
+				"unist-util-stringify-position": "^1.0.0",
+				"vfile-statistics": "^1.1.0"
 			}
 		},
 		"vfile-statistics": {
@@ -4057,7 +4057,7 @@
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"dev": true,
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"widest-line": {
@@ -4066,7 +4066,7 @@
 			"integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
 			"dev": true,
 			"requires": {
-				"string-width": "1.0.2"
+				"string-width": "^1.0.1"
 			}
 		},
 		"wordwrap": {
@@ -4087,7 +4087,7 @@
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"dev": true,
 			"requires": {
-				"mkdirp": "0.5.1"
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -4096,9 +4096,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"signal-exit": "3.0.2"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"write-json-file": {
@@ -4107,12 +4107,12 @@
 			"integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
 			"dev": true,
 			"requires": {
-				"detect-indent": "5.0.0",
-				"graceful-fs": "4.1.11",
-				"make-dir": "1.1.0",
-				"pify": "3.0.0",
-				"sort-keys": "2.0.0",
-				"write-file-atomic": "2.3.0"
+				"detect-indent": "^5.0.0",
+				"graceful-fs": "^4.1.2",
+				"make-dir": "^1.0.0",
+				"pify": "^3.0.0",
+				"sort-keys": "^2.0.0",
+				"write-file-atomic": "^2.0.0"
 			},
 			"dependencies": {
 				"pify": {
@@ -4127,7 +4127,7 @@
 					"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
 					"dev": true,
 					"requires": {
-						"is-plain-obj": "1.1.0"
+						"is-plain-obj": "^1.0.0"
 					}
 				}
 			}
@@ -4138,8 +4138,8 @@
 			"integrity": "sha1-NTqkTDnEjCFED1wIzmq9RhQcnAg=",
 			"dev": true,
 			"requires": {
-				"sort-keys": "1.1.2",
-				"write-json-file": "2.3.0"
+				"sort-keys": "^1.1.2",
+				"write-json-file": "^2.0.0"
 			}
 		},
 		"x-is-function": {
@@ -4166,31 +4166,31 @@
 			"integrity": "sha1-kqQusCpPsUnf6lUYAhkU9arIT/A=",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"debug": "2.6.9",
-				"deep-assign": "1.0.0",
-				"eslint": "3.19.0",
-				"eslint-config-xo": "0.18.2",
-				"eslint-formatter-pretty": "1.3.0",
-				"eslint-plugin-ava": "4.2.2",
-				"eslint-plugin-import": "2.8.0",
-				"eslint-plugin-no-use-extend-native": "0.3.12",
-				"eslint-plugin-promise": "3.6.0",
-				"eslint-plugin-unicorn": "2.1.2",
-				"get-stdin": "5.0.1",
-				"globby": "6.1.0",
-				"has-flag": "2.0.0",
-				"ignore": "3.3.7",
-				"lodash.isequal": "4.5.0",
-				"meow": "3.7.0",
-				"multimatch": "2.1.0",
-				"path-exists": "3.0.0",
-				"pkg-conf": "2.0.0",
-				"resolve-cwd": "1.0.0",
-				"resolve-from": "2.0.0",
-				"slash": "1.0.0",
-				"update-notifier": "2.3.0",
-				"xo-init": "0.5.0"
+				"arrify": "^1.0.0",
+				"debug": "^2.2.0",
+				"deep-assign": "^1.0.0",
+				"eslint": "^3.18.0",
+				"eslint-config-xo": "^0.18.0",
+				"eslint-formatter-pretty": "^1.0.0",
+				"eslint-plugin-ava": "^4.2.0",
+				"eslint-plugin-import": "^2.0.0",
+				"eslint-plugin-no-use-extend-native": "^0.3.2",
+				"eslint-plugin-promise": "^3.4.0",
+				"eslint-plugin-unicorn": "^2.1.0",
+				"get-stdin": "^5.0.0",
+				"globby": "^6.0.0",
+				"has-flag": "^2.0.0",
+				"ignore": "^3.2.6",
+				"lodash.isequal": "^4.4.0",
+				"meow": "^3.4.2",
+				"multimatch": "^2.1.0",
+				"path-exists": "^3.0.0",
+				"pkg-conf": "^2.0.0",
+				"resolve-cwd": "^1.0.0",
+				"resolve-from": "^2.0.0",
+				"slash": "^1.0.0",
+				"update-notifier": "^2.1.0",
+				"xo-init": "^0.5.0"
 			}
 		},
 		"xo-init": {
@@ -4199,13 +4199,13 @@
 			"integrity": "sha1-jijex5Z2zF4EL95f2PcQ4mRrDjY=",
 			"dev": true,
 			"requires": {
-				"arrify": "1.0.1",
-				"execa": "0.5.1",
-				"minimist": "1.2.0",
-				"path-exists": "3.0.0",
-				"read-pkg-up": "2.0.0",
-				"the-argv": "1.0.0",
-				"write-pkg": "2.1.0"
+				"arrify": "^1.0.0",
+				"execa": "^0.5.0",
+				"minimist": "^1.1.3",
+				"path-exists": "^3.0.0",
+				"read-pkg-up": "^2.0.0",
+				"the-argv": "^1.0.0",
+				"write-pkg": "^2.0.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -4214,8 +4214,8 @@
 					"integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.1",
-						"which": "1.3.0"
+						"lru-cache": "^4.0.1",
+						"which": "^1.2.9"
 					}
 				},
 				"execa": {
@@ -4224,13 +4224,13 @@
 					"integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "4.0.2",
-						"get-stream": "2.3.1",
-						"is-stream": "1.1.0",
-						"npm-run-path": "2.0.2",
-						"p-finally": "1.0.0",
-						"signal-exit": "3.0.2",
-						"strip-eof": "1.0.0"
+						"cross-spawn": "^4.0.0",
+						"get-stream": "^2.2.0",
+						"is-stream": "^1.1.0",
+						"npm-run-path": "^2.0.0",
+						"p-finally": "^1.0.0",
+						"signal-exit": "^3.0.0",
+						"strip-eof": "^1.0.0"
 					}
 				},
 				"get-stream": {
@@ -4239,8 +4239,8 @@
 					"integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
 					"dev": true,
 					"requires": {
-						"object-assign": "4.1.1",
-						"pinkie-promise": "2.0.1"
+						"object-assign": "^4.0.1",
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"phrases.json"
 	],
 	"dependencies": {
-		"lodash.difference": "^4.5.0",
+		"lodash": ">= 4.17.5",
 		"nlcst-search": "^1.4.2",
 		"nlcst-to-string": "^2.0.1",
 		"quotation": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"phrases.json"
 	],
 	"dependencies": {
-		"lodash": ">= 4.17.5",
+		"lodash": "^4.17.5",
 		"nlcst-search": "^1.4.2",
 		"nlcst-to-string": "^2.0.1",
 		"quotation": "^1.1.0",


### PR DESCRIPTION
I received a warning from [Sonatype DepShield](https://www.sonatype.com/depshield) that retext-assuming is using a vulnerable version of lodash and points to [this advisory](https://www.npmjs.com/advisories/577).

So maybe this repo can be updated to lodash 4.17.5.

npm also pointed out other vulnerable dependencies that could be fixed with `npm audit fix`.
Since running `npm install` without changes already created a diff in `package-lock.json`, I moved that in a separate commit. If you prefer to have the changes in one commit, you are of course free to  squash merge, I just wanted to separate the changes for better readability :slightly_smiling_face: 